### PR TITLE
Created Pet Profile Page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ import { ProfilePage } from "./pages/profile-page";
 import { PetsPage } from "./pages/pets-page";
 import { AddPetPage } from "./pages/add-pet-page";
 import { PetProfilePage } from "./pages/pet-profile-page";
+import { UpdatePetProfilePage } from "./pages/update-pet-profile";
 
 export const App = () => {
   const { isLoading } = useAuth0();
@@ -37,6 +38,10 @@ export const App = () => {
       <Route
         path="/petProfile"
         element={<AuthenticationGuard component={PetProfilePage} />}
+      />
+      <Route
+        path="/updatePetProfile"
+        element={<AuthenticationGuard component={UpdatePetProfilePage} />}
       />
       <Route
         path="/pets"

--- a/src/pages/pet-profile-page.js
+++ b/src/pages/pet-profile-page.js
@@ -1,42 +1,50 @@
-import React, { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
-import { CodeSnippet } from "../components/code-snippet";
+import { useLocation, useNavigate } from "react-router-dom";
 import { PageLayout } from "../components/page-layout";
-import { getProtectedResource } from "../services/message.service";
-import { useAuth0 } from '@auth0/auth0-react';
+import { useAuth0 } from "@auth0/auth0-react";
+import { useState, useEffect } from "react";
+import {
+  deletePetResource,
+  updatePetResource,
+} from "../services/message.service";
 
 export const PetProfilePage = () => {
-  const [message, setMessage] = useState("");
-  const { getAccessTokenSilently } = useAuth0();
+  const { user, getAccessTokenSilently } = useAuth0();
   const location = useLocation();
+  const navigate = useNavigate();
+  const [petData, setPetData] = useState(location.state);
 
   useEffect(() => {
-    let isMounted = true;
+    setPetData(location.state);
+  }, [location.state]);
 
-    const getMessage = async () => {
-      const accessToken = await getAccessTokenSilently();
-      const { data, error } = await getProtectedResource(accessToken);
-      console.log(location.state);
+  const handlePetUpdateButton = () => {
+    navigate("/updatePetProfile", { state: { petData } });
+  };
 
-      if (!isMounted) {
-        return;
-      }
+  const handleDeletePetProfile = async (id) => {
+    const accessToken = await getAccessTokenSilently();
+    await deletePetResource(accessToken, id);
+    navigate("/pets");
+  };
 
-      if (data) {
-        setMessage(JSON.stringify(location.state));
-      }
-
-      if (error) {
-        setMessage(JSON.stringify(error, null, 2));
-      }
+  const handleAdoptPet = async (id) => {
+    const updatedPet = {
+      availability: "not available",
     };
-
-    getMessage();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
+    console.log(updatedPet);
+    const accessToken = await getAccessTokenSilently();
+    const { data, error } = await updatePetResource(
+      accessToken,
+      id,
+      updatedPet
+    );
+    if (data && !error) {
+      setPetData((prevData) => ({
+        ...prevData,
+        availability: updatedPet.availability,
+      }));
+    }
+  };
 
   return (
     <PageLayout>
@@ -44,17 +52,50 @@ export const PetProfilePage = () => {
         <h1 id="page-title" className="content__title">
           Pet Profile Page
         </h1>
+        <img
+          style={{ height: "auto", width: "50%" }}
+          src={petData.images[0]}
+          alt={petData.breed}
+        />
         <div className="content__body">
-          <p id="page-description">
-            <span>
-              This page retrieves the pet information from an
-              external API.
-            </span>
-            <span>
-              <strong>Only registered visitors can access this page.</strong>
-            </span>
-          </p>
-          <CodeSnippet title="Private Message" code={message} />
+          <p>{petData.description}</p>
+
+          <ul>
+            <li>
+              <strong>Type of animal: </strong> {petData.typeAnimal}
+            </li>
+            <li>
+              <strong>Good with children: </strong>{" "}
+              {petData.goodWithChildren ? "Yes" : "No"}
+            </li>
+            <li>
+              <strong>Good with other animals: </strong>{" "}
+              {petData.goodWithAnimals ? "Yes" : "No"}
+            </li>
+            <li>
+              <strong>Needs to be leashed at all times: </strong>{" "}
+              {petData.leashedAllTimes ? "Yes" : "No"}
+            </li>
+            <li>
+              <strong>Availability: </strong> {petData.availability}
+            </li>
+          </ul>
+          {user?.role === "admin" && (
+            <>
+              <button onClick={handlePetUpdateButton}>Update</button>
+              <button onClick={() => handleDeletePetProfile(petData.id)}>
+                Delete
+              </button>
+            </>
+          )}
+          {user?.role === "user" && (
+            <button
+              onClick={() => handleAdoptPet(petData.id)}
+              disabled={petData.availability.toLowerCase() !== "available"}
+            >
+              Adopt
+            </button>
+          )}
         </div>
       </div>
     </PageLayout>

--- a/src/pages/update-pet-profile.js
+++ b/src/pages/update-pet-profile.js
@@ -1,0 +1,21 @@
+import { useLocation } from "react-router-dom";
+import { PageLayout } from "../components/page-layout";
+import { useAuth0 } from "@auth0/auth0-react";
+
+export const UpdatePetProfilePage = () => {
+  const { user } = useAuth0();
+  const location = useLocation();
+  const petData = location.state;
+  console.log(petData);
+
+  return (
+    <PageLayout>
+      <div className="content-layout">
+        <h1 id="page-title" className="content__title">
+          Update Pet Profile Page
+        </h1>
+        <div className="content__body"></div>
+      </div>
+    </PageLayout>
+  );
+};

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -123,3 +123,40 @@ export const createPetResource = async (accessToken, requestBody) => {
     error,
   };
 };
+
+export const deletePetResource = async (accessToken, id) => {
+  const config = {
+    url: `${apiServerUrl}/pets/${id}`,
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  };
+
+  const { data, error } = await callExternalApi({ config });
+
+  return {
+    data: data || null,
+    error,
+  };
+};
+
+export const updatePetResource = async (accessToken, id, requestBody) => {
+  const config = {
+    url: `${apiServerUrl}/pets/${id}`,
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    data: requestBody,
+  };
+
+  const { data, error } = await callExternalApi({ config });
+
+  return {
+    data: data || null,
+    error,
+  };
+};


### PR DESCRIPTION
- Created pet profile page.
- `Delete` and `Update` buttons are viewable only when logged onto admin.
- `Adopt` button only available as a public user.
- The `Delete` button is hooked up to the backend. The user is directed to the `/pets` page.
- The `Update` button routes the user to a `UpdatePetProfile` page **(This is to be implemented by Paul)**.
- A public user can adopt an available pet on the spot. The button will grey out immediately after pressing adopt. The button will also be disabled for pets that are unavailable.
- ***TODO***: Adopted pets are not assigned to a user. So there's no way to keep track of which user adopted which pet for now. This means that users who adopted pets cannot cancel adoptions, only admins can. This might be fixed for a later TODO.